### PR TITLE
Revert trust policy to specify the branch.

### DIFF
--- a/.github/chainguard/presubmit-testing.sts.yaml
+++ b/.github/chainguard/presubmit-testing.sts.yaml
@@ -4,7 +4,7 @@
 issuer: https://token.actions.githubusercontent.com
 subject: repo:chainguard-dev/ghaudit:pull_request
 claim_pattern:
-  workflow_ref: chainguard-dev/ghaudit/\.github/workflows/presubmit-testing\.yaml@.* # TODO(mattmoor): change this back to refs/heads/main (for PRT)
+  workflow_ref: chainguard-dev/ghaudit/\.github/workflows/presubmit-testing\.yaml@refs/heads/main
 
 # This is running untrusted code in a public repository as pull_request_target.
 # Seek a security review before changing these permissions.


### PR DESCRIPTION
I believe the `workflow_ref` claim should always be `refs/heads/main` for `pull_request_target`.