### PR TITLE
Filter repositories with `no-ghaudit` topic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,11 @@ require (
 	github.com/google/go-github/v60 v60.0.0
 	github.com/spf13/cobra v1.8.0
 	golang.org/x/oauth2 v0.18.0
+	k8s.io/apimachinery v0.29.3
 )
 
 require (
-	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
-github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
-github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
+github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
@@ -53,3 +53,5 @@ google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGm
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+k8s.io/apimachinery v0.29.3 h1:2tbx+5L7RNvqJjn7RIuIKu9XTsIZ9Z5wX2G22XAa5EU=
+k8s.io/apimachinery v0.29.3/go.mod h1:hx/S4V2PNW4OMg3WizRrHutyB5la0iCUbZym+W0EQIU=

--- a/pkg/org/branchprotections.go
+++ b/pkg/org/branchprotections.go
@@ -10,7 +10,7 @@ import (
 )
 
 func branchProtections(ghc *github.Client, org *string) *cobra.Command {
-	rm := NewRepoMapper(ghc, org, repo.BranchProtections)
+	rm := NewRepoMapper("branch-protections", ghc, org, repo.BranchProtections)
 
 	return &cobra.Command{
 		Use:           "branch-protections",

--- a/pkg/org/defaultpermissions.go
+++ b/pkg/org/defaultpermissions.go
@@ -10,7 +10,7 @@ import (
 )
 
 func defaultPermissions(ghc *github.Client, org *string) *cobra.Command {
-	rm := NewRepoMapper(ghc, org, repo.DefaultPermissions)
+	rm := NewRepoMapper("default-permissions", ghc, org, repo.DefaultPermissions)
 
 	return &cobra.Command{
 		Use:           "default-permissions",

--- a/pkg/org/deploykeys.go
+++ b/pkg/org/deploykeys.go
@@ -10,7 +10,7 @@ import (
 )
 
 func deployKeys(ghc *github.Client, org *string) *cobra.Command {
-	rm := NewRepoMapper(ghc, org, repo.DeployKeys)
+	rm := NewRepoMapper("deploy-keys", ghc, org, repo.DeployKeys)
 
 	return &cobra.Command{
 		Use:           "deploy-keys",


### PR DESCRIPTION
These only filter things from the `ghaudit org` command.

The topic `no-ghaudit` will disable all checks.

The topic `no-ghaudit:COMMAND` will disable the `ghaudit org COMMAND` check (e.g. `no-ghaudit:deploy-keys`).