### PR TITLE
fix(ci): GitHub Actions security hardening

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3
     groups:
       all:
         update-types:
@@ -16,6 +18,8 @@ updates:
     directory: "./"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3
     groups:
       all:
         update-types:

--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -5,15 +5,9 @@ name: Action Lint
 on:
   pull_request:
     branches: ['main']
-    paths:
-      - '.github/workflows/**'
-      - '.github/actions/**'
 
   push:
     branches: ['main']
-    paths:
-      - '.github/workflows/**'
-      - '.github/actions/**'
 
 permissions: {}
 

--- a/.github/workflows/presubmit-testing.yaml
+++ b/.github/workflows/presubmit-testing.yaml
@@ -40,26 +40,29 @@ jobs:
     - name: Check default permissions
       env:
         GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
+        REPO_NAME: ${{ github.event.repository.name }}
       run: |
         go run . repo \
-          --organization ${{ github.repository_owner }} \
-          --repository ${{ github.event.repository.name }} \
+          --organization "${GITHUB_REPOSITORY_OWNER}" \
+          --repository "${REPO_NAME}" \
           default-permissions
 
     - name: Check for deploy keys
       env:
         GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+        REPO_NAME: ${{ github.event.repository.name }}
       run: |
         go run . repo \
-          --organization ${{ github.repository_owner }} \
-          --repository ${{ github.event.repository.name }} \
+          --organization "${GITHUB_REPOSITORY_OWNER}" \
+          --repository "${REPO_NAME}" \
           deploy-keys
 
     - name: Check branch protections
       env:
         GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+        REPO_NAME: ${{ github.event.repository.name }}
       run: |
         go run . repo \
-          --organization ${{ github.repository_owner }} \
-          --repository ${{ github.event.repository.name }} \
+          --organization "${GITHUB_REPOSITORY_OWNER}" \
+          --repository "${REPO_NAME}" \
           branch-protections

--- a/.github/workflows/presubmit-testing.yaml
+++ b/.github/workflows/presubmit-testing.yaml
@@ -25,6 +25,8 @@ jobs:
         egress-policy: audit
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,15 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yaml'
+      - '.github/zizmor.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yaml'
+      - '.github/zizmor.yml'
 
 permissions: {}
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,15 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+rules:
+  # Paired with `cooldown.default-days: 3` in .github/dependabot.yaml.
+  dependabot-cooldown:
+    config:
+      days: 3
+  # Cosmetic pedantic-only findings — suppressed across the campaign.
+  anonymous-definition:
+    disable: true
+  undocumented-permissions:
+    disable: true
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION
Automated GitHub Actions security hardening (zizmor + actionlint + shellcheck,
plus manual review). Four focused, workflow-config-only changes — no
application code is touched.

## Changes

- **Scope down checkout credentials** — `persist-credentials: false` on the
  `presubmit-testing.yaml` checkout. The job passes its token explicitly to the
  steps that need it, so leaving the checkout token in `.git/config` for later
  steps is unnecessary exposure.

- **Move template expressions into `env`** — `${{ … }}` interpolations in
  `presubmit-testing.yaml` `run:` blocks are hoisted into quoted `env:` aliases
  (built-ins use the `$GITHUB_*` variables). This removes the shell
  script-injection surface created by expanding expressions directly into
  inline scripts.

- **Stop the required "Action lint" check from being un-runnable** —
  `actionlint.yaml` gated its triggers on a `paths:` filter, but its
  **"Action lint" status check is required** by branch protection on `main`. A
  PR that touches no workflow files would never trigger it, so the required
  check would sit permanently pending and block merge. Removing the `paths:`
  filter so the check runs on every PR (fail-closed).

- **Add a zizmor config + dependabot cooldown** — a `.github/zizmor.yml` that
  disables a few cosmetic pedantic rules, and a 3-day cooldown on each
  dependabot ecosystem so brand-new (and potentially compromised) dependency
  releases aren't pulled the instant they ship.

## Note for reviewer

This PR is from a fork. Because patch 0002 makes the **"Action lint"** check run
on all PRs, it will now run on this PR too (intended). Any OIDC / octo-sts
steps in the privileged workflows that depend on repository-scoped identity may
report as failed or skipped in a fork PR for environmental reasons unrelated to
these changes.

Refs: PSEC-923